### PR TITLE
2.5.20 optimisation fixes 2.5.21

### DIFF
--- a/lib/client/base.js
+++ b/lib/client/base.js
@@ -674,11 +674,13 @@ HappnClient.prototype.delegate_handover = function(message, delegate){
 			if (e)
 				return _this.handle_error(e);
 
-			delegate.handler.call(_this, message.data, message._meta);
+			if (delegate.handler)
+				delegate.handler.call(_this, message.data, message._meta);
 		});
 	}
 
-	delegate.handler.call(_this, message.data, message._meta);
+	if (delegate.handler)
+		delegate.handler.call(_this, message.data, message._meta);
 }
 
 HappnClient.prototype.handle_data = function(path, message){

--- a/lib/client/base.js
+++ b/lib/client/base.js
@@ -674,13 +674,11 @@ HappnClient.prototype.delegate_handover = function(message, delegate){
 			if (e)
 				return _this.handle_error(e);
 
-			if (delegate.handler)
-				delegate.handler.call(_this, message.data, message._meta);
+			delegate.handler.call(_this, message.data, message._meta);
 		});
 	}
 
-	if (delegate.handler)
-		delegate.handler.call(_this, message.data, message._meta);
+	delegate.handler.call(_this, message.data, message._meta);
 }
 
 HappnClient.prototype.handle_data = function(path, message){

--- a/lib/service.js
+++ b/lib/service.js
@@ -256,27 +256,24 @@ module.exports = {
             function(serviceName, stopServiceCB) {
               var serviceInstance = happn.services[serviceName];
 
-              if (serviceInstance.stop)
+              if (serviceInstance.stop){
                 serviceInstance.stop(options, stopServiceCB);
+              }
               else
                 stopServiceCB();
 
             },
             function(e) {
 
-              if (e) return stopCB(e); // not stopping network
+              if (e)
+                return stopCB(e); // not stopping network
 
-              // stop the server
-              log.$$DEBUG('stopped services');
-              // var info = happn.server.address();
-
+              //drop all connections
               for (var key in happn.connections)
                 happn.connections[key].destroy();
 
               log.$$TRACE('killed connections');
-              // log.$$TRACE('killed connections', _this.connections); // Too long
-              // log.$$TRACE('killed connections', Object.keys(_this.connections)); // Too expensive
-
+              log.$$DEBUG('stopped services');
 
               ///// primus closes the http server
               ///// see primus.destroy() in services/pubsub/service

--- a/lib/services/pubsub/service.js
+++ b/lib/services/pubsub/service.js
@@ -44,16 +44,41 @@ PubSubService.prototype.stats = function(opts){
 
 PubSubService.prototype.stop = function(options, done){
     try{
+
+    	var _this = this;
+
+    	if (typeof options == 'function'){
+    		done = options;
+    		options = {};
+    	}
+
     	if (this.primus){
+
+    		if (!options.timeout)
+    			options.timeout = 5000;
+
+    		var shutdownTimeout = setTimeout(function(){
+	    		_this.log.error('primus destroy timed out after ' + options.timeout + ' milliseconds');
+	    		_this.__shutdownTimeout = true;//instance level flag to ensure done is not called multiple times
+	    		done();
+	    	}, options.timeout)
+
     		this.primus.destroy({
     			// // have primus close the http server and clean up
     			close: true,
     			// have primus inform clients to attempt reconnect
     			reconnect: typeof options.reconnect === 'boolean' ? options.reconnect : true
-    		}, done);
+    		}, function(e){
+    			//we ensure that primus didn't time out earlier
+    			if (!_this.__shutdownTimeout){
+    				clearTimeout(shutdownTimeout);
+    				done(e);
+    			}
+    		});
     	}
     	else
         	done();
+
     }catch(e){
         done(e);
     }
@@ -68,6 +93,7 @@ PubSubService.prototype.initialize = function(config, done) {
 
 		_this.dataService = _this.happn.services.data;
 		_this.securityService = _this.happn.services.security.safe();
+		_this.__shutdownTimeout = false;//used to flag an incomplete shutdown
 
 		if (config.secure){
 
@@ -600,6 +626,7 @@ PubSubService.prototype.connectLocal = function(handler, session) {
 	var _this = this;
 
 	var socket = {
+		intraProc:true,
 		write: function(message) {
 			handler(message);
 		},
@@ -646,11 +673,21 @@ PubSubService.prototype.emitToAudience = function(publication, channel) {
 
 	if (audienceGroup[channel] != null && audienceGroup[channel] != undefined) {
 
-		var publicationSerialized = JSON.stringify(publication);
+		var serialized;
+		var decoupledPublication;
 
 		for (var sessionIndex in audienceGroup[channel]) {
 
-			var decoupledPublication = JSON.parse(publicationSerialized);
+			if (_this.__sessions[sessionIndex].intraProc){
+				//we deep clone for intra process comms
+				decoupledPublication = _this.happn.utils.clone(publication, true);
+			}else{
+				//only JSON can make it over the wire anyhow, may as well use JSON
+				if (!serialized)
+					serialized = JSON.stringify(publication);
+
+				decoupledPublication = JSON.parse(serialized);
+			}
 
 			decoupledPublication._meta.channel = channel.toString();
 			decoupledPublication._meta.sessionId = _this.__sessions[sessionIndex].session.id;


### PR DESCRIPTION
Hi guys, I needed to modify the optimisations for happner to function correctly, the main change here is that we do a deep-copy when emitting to an intra-process subscriber. Also, when there are any connections that are not websockets, Primus.destroy just freezes - so I added a timeout on the pubsub services "stop" method to pass control back to the happn server, which destroys the primus connections. All happn tests are passing, and with these modifications, all happner tests are passing.