### PR TITLE
Remove primus save 2.7.1

### DIFF
--- a/lib/services/pubsub/service.js
+++ b/lib/services/pubsub/service.js
@@ -124,9 +124,11 @@ PubSubService.prototype.initialize = function(config, done) {
 		var clientPath = path.resolve(__dirname, '../../public');
 
 		// happner is using this to create the api/client package
-		_this.script = process.env.PRIMUS_SCRIPT || clientPath + '/browser_primus.js';
+		_this.script = clientPath + '/browser_primus.js';
 
-		_this.primus.save(_this.script);
+    if (process.env.UPDATE_BROWSER_PRIMUS) {
+      _this.primus.save(_this.script);
+    }
 
 		_this.config = config;
 

--- a/test/0_startup.js
+++ b/test/0_startup.js
@@ -1,0 +1,45 @@
+var path = require('path');
+var filename = path.basename(__filename);
+var happn = require('../lib/index');
+var service = happn.service;
+
+describe(filename, function() {
+
+  require('benchmarket').start();
+  after(require('benchmarket').store());
+
+  beforeEach(function() {
+    delete process.env.UPDATE_BROWSER_PRIMUS;
+  });
+
+  afterEach(function(done) {
+    if (!this.server) return done();
+    this.server.stop(done);
+  });
+
+  it('update browser_primus script', function(done) {
+    // Primus requires dynamic creation of the clientside script,
+    // We are putting this dynamically created script into lib/public,
+    // so that there is no need to RE-create the client script with each happn startup
+    //
+    // This test does that update so that when primus in upgraded in package.json
+    // the corresponding new browser_primus is also kept up-to-date.
+    process.env.UPDATE_BROWSER_PRIMUS = '1';
+    var _this = this;
+    service.create().then(function(server) {
+      _this.server = server;
+      done();
+    }).catch(done);
+  });
+
+  it('default startup time', function(done) {
+    var _this = this;
+    service.create().then(function(server) {
+      _this.server = server;
+      done();
+    }).catch(done);
+  });
+
+  require('benchmarket').stop();
+
+});


### PR DESCRIPTION
Happn no longer (re-)saves browser_primus at every startup.
Instead, one of the test does it (to ensure it remains up-to-date)
