### PR TITLE
Emit optimisations 2.7.2

### DIFF
--- a/lib/client/plugins/intra-process.js
+++ b/lib/client/plugins/intra-process.js
@@ -183,8 +183,8 @@ module.exports = {
 			parameters = {};
 		}
     _this.setImmediate(function(){
-			_this.setInternal(path, data, parameters, handler);
-		}, _this.options.config.deferSetImmediate);
+      _this.setInternal(path, data, parameters, handler);
+    }, _this.options.config.deferSetImmediate);
 	}),
 	setInternal:function(path, data, parameters, handler){
     // this.context.log.info('XXX - setInternal()');

--- a/lib/client/plugins/intra-process.js
+++ b/lib/client/plugins/intra-process.js
@@ -65,7 +65,7 @@ module.exports = {
 	}),
 
 	validateRequest:function(path, action, data, parameters, handler){
-    this.context.log.info('XXX - validateRequest()');
+    // this.context.log.info('XXX - validateRequest()');
 
 		if (['login','set','get','remove','describe'].indexOf(action) == -1){
 			var error = new Error("invalid action: " + action);
@@ -80,7 +80,7 @@ module.exports = {
 	},
 
 	authorizeRequest:function(message, handler, callback){
-    this.context.log.info('XXX - authorizeRequest()');
+    // this.context.log.info('XXX - authorizeRequest()');
 
 		if (this.pubsub.trusted[this.session.id] == undefined) return this.pubsub.handleDataResponseLocal(this.securityService.AccessDeniedError('unauthorized'), message, null, handler, this);
 
@@ -112,7 +112,7 @@ module.exports = {
 	},
 
 	performRequest:function(path, action, data, parameters, handler) {
-    this.context.log.info('XXX - performRequest()');
+    // this.context.log.info('XXX - performRequest()');
 
 		if (!parameters)
 			parameters = {};
@@ -133,7 +133,7 @@ module.exports = {
 		var _this = this;
 
 		this.authorizeRequest(message, handler, function(){
-      _this.context.log.info('XXX - request authorized');
+      // _this.context.log.info('XXX - request authorized');
 
 			if (action == "set"){
 				if (parameters.noStore) {
@@ -176,7 +176,7 @@ module.exports = {
 		});
 	}),
 	set: Promise.promisify(function(path, data, parameters, handler){
-    this.context.log.info('XXX - set()');
+    // this.context.log.info('XXX - set()');
 		var _this = this;
 		if (typeof parameters == 'function') {
 			handler = parameters;
@@ -187,7 +187,7 @@ module.exports = {
 		}, _this.options.config.deferSetImmediate);
 	}),
 	setInternal:function(path, data, parameters, handler){
-    this.context.log.info('XXX - setInternal()');
+    // this.context.log.info('XXX - setInternal()');
 		this.performRequest(path, "set", data, parameters, handler);
 	},
 	_remoteOff:function(channel, refCount, done){

--- a/lib/client/plugins/intra-process.js
+++ b/lib/client/plugins/intra-process.js
@@ -65,6 +65,7 @@ module.exports = {
 	}),
 
 	validateRequest:function(path, action, data, parameters, handler){
+    this.context.log.info('XXX - validateRequest()');
 
 		if (['login','set','get','remove','describe'].indexOf(action) == -1){
 			var error = new Error("invalid action: " + action);
@@ -79,6 +80,7 @@ module.exports = {
 	},
 
 	authorizeRequest:function(message, handler, callback){
+    this.context.log.info('XXX - authorizeRequest()');
 
 		if (this.pubsub.trusted[this.session.id] == undefined) return this.pubsub.handleDataResponseLocal(this.securityService.AccessDeniedError('unauthorized'), message, null, handler, this);
 
@@ -110,6 +112,7 @@ module.exports = {
 	},
 
 	performRequest:function(path, action, data, parameters, handler) {
+    this.context.log.info('XXX - performRequest()');
 
 		if (!parameters)
 			parameters = {};
@@ -130,9 +133,12 @@ module.exports = {
 		var _this = this;
 
 		this.authorizeRequest(message, handler, function(){
+      _this.context.log.info('XXX - request authorized');
 
 			if (action == "set"){
-				if (parameters.noStore) return _this.pubsub.handleDataResponseLocal(null, message, _this.dataService.formatSetData(path, data), handler, _this);
+				if (parameters.noStore) {
+          return _this.pubsub.handleDataResponseLocal(null, message, _this.dataService.formatSetData(path, data), handler, _this);
+        }
 
 				_this.dataService.upsert(path, data, parameters, function(e, response){
 					return _this.pubsub.handleDataResponseLocal(e, message, response, handler, _this);
@@ -170,17 +176,18 @@ module.exports = {
 		});
 	}),
 	set: Promise.promisify(function(path, data, parameters, handler){
+    this.context.log.info('XXX - set()');
 		var _this = this;
 		if (typeof parameters == 'function') {
 			handler = parameters;
 			parameters = {};
 		}
-
-		_this.setImmediate(function(){
+    _this.setImmediate(function(){
 			_this.setInternal(path, data, parameters, handler);
 		}, _this.options.config.deferSetImmediate);
 	}),
 	setInternal:function(path, data, parameters, handler){
+    this.context.log.info('XXX - setInternal()');
 		this.performRequest(path, "set", data, parameters, handler);
 	},
 	_remoteOff:function(channel, refCount, done){

--- a/lib/services/data_embedded/service.js
+++ b/lib/services/data_embedded/service.js
@@ -488,7 +488,7 @@ DataEmbeddedService.prototype.get = function(path, parameters, callback){
 
 DataEmbeddedService.prototype.formatSetData = function(path, data){
 
-  this.log.info('XXX - formatSetData()');
+  // this.log.info('XXX - formatSetData()');
 
   if (typeof data != 'object' || data instanceof Array == true || data instanceof Date == true || data == null)
     data = {value:data};
@@ -504,7 +504,7 @@ DataEmbeddedService.prototype.formatSetData = function(path, data){
 }
 
 DataEmbeddedService.prototype.upsert = function(path, data, options, callback){
-  this.log.info('XXX - upsert()');
+  // this.log.info('XXX - upsert()');
   var _this = this;
 
   options = options?options:{};
@@ -583,7 +583,7 @@ DataEmbeddedService.prototype.transform = function(dataObj, meta){
 }
 
 DataEmbeddedService.prototype.__upsertInternal = function(path, setData, options, dataWasMerged, callback){
-  this.log.info('XXX - __upsertInternal()');
+  // this.log.info('XXX - __upsertInternal()');
   var _this = this;
   var setParameters = {$set: {"data":setData.data, "_id":setData._meta.path}};
 

--- a/lib/services/data_embedded/service.js
+++ b/lib/services/data_embedded/service.js
@@ -488,6 +488,8 @@ DataEmbeddedService.prototype.get = function(path, parameters, callback){
 
 DataEmbeddedService.prototype.formatSetData = function(path, data){
 
+  this.log.info('XXX - formatSetData()');
+
   if (typeof data != 'object' || data instanceof Array == true || data instanceof Date == true || data == null)
     data = {value:data};
 
@@ -502,6 +504,7 @@ DataEmbeddedService.prototype.formatSetData = function(path, data){
 }
 
 DataEmbeddedService.prototype.upsert = function(path, data, options, callback){
+  this.log.info('XXX - upsert()');
   var _this = this;
 
   options = options?options:{};
@@ -580,6 +583,7 @@ DataEmbeddedService.prototype.transform = function(dataObj, meta){
 }
 
 DataEmbeddedService.prototype.__upsertInternal = function(path, setData, options, dataWasMerged, callback){
+  this.log.info('XXX - __upsertInternal()');
   var _this = this;
   var setParameters = {$set: {"data":setData.data, "_id":setData._meta.path}};
 

--- a/lib/services/pubsub/service.js
+++ b/lib/services/pubsub/service.js
@@ -744,10 +744,8 @@ PubSubService.prototype.disconnect = function(socket) {
 PubSubService.prototype.getAudienceGroup = function(channel, opts) {
   // this.log.info('XXX - getAudienceGroup() %s', channel);
 
-  var _this = this;
-
   if (channel == '/ALL@*')//listeners subscribed to everything
-    return _this.__listeners_ONALL;
+    return this.__listeners_ONALL;
 
   if (!opts) {
     // opts is missing in calls from addListener() and removeListener()
@@ -757,13 +755,9 @@ PubSubService.prototype.getAudienceGroup = function(channel, opts) {
     }
   }
 
-	if (opts.hasWildcard && opts.targetAction == 'ALL'){//listeners subscribed to any action, but on a partial path
-		return _this.__listeners_wildcard_ALL;
-	} else if (opts.hasWildcard){//listeners subscribed to a specific action, but on a partial path
-		return _this['__listeners_wildcard_' + opts.targetAction];
-	} else {
-		return _this['__listeners_' + opts.targetAction];
-	}
+  if (opts.hasWildcard) return this['__listeners_wildcard_' + opts.targetAction];
+  return this['__listeners_' + opts.targetAction];
+  
 }
 
 PubSubService.prototype.emitToAudience = function(publication, channel, opts) {

--- a/lib/services/pubsub/service.js
+++ b/lib/services/pubsub/service.js
@@ -757,7 +757,7 @@ PubSubService.prototype.getAudienceGroup = function(channel, opts) {
     }
   }
 
-	if (opts.hasWildcard && targetAction == 'ALL'){//listeners subscribed to any action, but on a partial path
+	if (opts.hasWildcard && opts.targetAction == 'ALL'){//listeners subscribed to any action, but on a partial path
 		return _this.__listeners_wildcard_ALL;
 	} else if (opts.hasWildcard){//listeners subscribed to a specific action, but on a partial path
 		return _this['__listeners_wildcard_' + opts.targetAction];

--- a/lib/services/pubsub/service.js
+++ b/lib/services/pubsub/service.js
@@ -763,7 +763,7 @@ PubSubService.prototype.getAudienceGroup = function(channel) {
 }
 
 PubSubService.prototype.emitToAudience = function(publication, channel, sharedRef) {
-  this.log.info('XXX - emitToAudience()');
+  this.log.info('XXX - emitToAudience() %s', channel);
 	var _this = this;
 
 	var audienceGroup = _this.getAudienceGroup(channel);

--- a/lib/services/pubsub/service.js
+++ b/lib/services/pubsub/service.js
@@ -757,7 +757,7 @@ PubSubService.prototype.getAudienceGroup = function(channel, opts) {
     }
   }
 
-	if (opts.hasWildcard && channel.indexOf('/ALL@') == 0){//listeners subscribed to any action, but on a partial path
+	if (opts.hasWildcard && targetAction == 'ALL'){//listeners subscribed to any action, but on a partial path
 		return _this.__listeners_wildcard_ALL;
 	} else if (opts.hasWildcard){//listeners subscribed to a specific action, but on a partial path
 		return _this['__listeners_wildcard_' + opts.targetAction];

--- a/lib/services/pubsub/service.js
+++ b/lib/services/pubsub/service.js
@@ -741,32 +741,36 @@ PubSubService.prototype.disconnect = function(socket) {
 	}
 }
 
-PubSubService.prototype.getAudienceGroup = function(channel) {
-  this.log.info('XXX - getAudienceGroup()');
-	var _this = this;
+PubSubService.prototype.getAudienceGroup = function(channel, opts) {
+  this.log.info('XXX - getAudienceGroup() %s', channel);
 
-	if (channel == '/ALL@*')//listeners subscribed to everything
-		return _this.__listeners_ONALL;
+  var _this = this;
 
-  // optimisation: indexOf(*) below is probably faster as `channel[channel.length - 1] == '*'`
-  // (assuming wildcards are only ever /at/the/end/of/the/path/*)
+  if (channel == '/ALL@*')//listeners subscribed to everything
+    return _this.__listeners_ONALL;
 
-  var hasWildcard = channel.indexOf('*') > -1;
+  if (!opts) {
+    // opts is missing in calls from addListener() and removeListener()
+    opts = {
+      hasWildcard: channel.indexOf('*') > -1,
+      targetAction: channel.split('@')[0].replace('/','')
+    }
+  }
 
-	if (hasWildcard && channel.indexOf('/ALL@') == 0){//listeners subscribed to any action, but on a partial path
+	if (opts.hasWildcard && channel.indexOf('/ALL@') == 0){//listeners subscribed to any action, but on a partial path
 		return _this.__listeners_wildcard_ALL;
-	} else if (hasWildcard){//listeners subscribed to a specific action, but on a partial path
-		return _this['__listeners_wildcard_' + channel.split('@')[0].replace('/','')];
+	} else if (opts.hasWildcard){//listeners subscribed to a specific action, but on a partial path
+		return _this['__listeners_wildcard_' + opts.targetAction];
 	} else {
-		return _this['__listeners_' + channel.split('@')[0].replace('/','')];
+		return _this['__listeners_' + opts.targetAction];
 	}
 }
 
-PubSubService.prototype.emitToAudience = function(publication, channel, sharedRef) {
+PubSubService.prototype.emitToAudience = function(publication, channel, opts) {
   this.log.info('XXX - emitToAudience() %s', channel);
 	var _this = this;
 
-	var audienceGroup = _this.getAudienceGroup(channel);
+	var audienceGroup = _this.getAudienceGroup(channel, opts);
 
 	if (audienceGroup[channel] != null && audienceGroup[channel] != undefined) {
 
@@ -788,14 +792,15 @@ PubSubService.prototype.emitToAudience = function(publication, channel, sharedRe
         // }
         // decoupledPublication = sharedRef.publication;
 
-        if (!sharedRef.serialized) {
-          sharedRef.serialized = JSON.stringify(publication)
+        if (!opts.serialized) {
+          opts.serialized = JSON.stringify(publication)
         }
         // still requires a separate copy per subscriber
         // but only when payload encryption is turned on,
-        // for all other cases the data is cloned by virtue
-        // of the fact that it crosses the network
-        decoupledPublication = JSON.parse(sharedRef.serialized);
+        // for all other cases this step could be shared
+        // because the data is cloned by virtue of the fact
+        // that it crosses the network
+        decoupledPublication = JSON.parse(opts.serialized);
 			}
 
 			decoupledPublication._meta.channel = channel.toString();
@@ -822,23 +827,30 @@ PubSubService.prototype.publish = function(message, payload) {
 	payload._meta.action = messageChannel;
 	payload._meta.type = 'data';
 
-  var sharedRef = {}; // so that serialised payload can be shared between
-                      // multiple calls to emitAudience() below
+  var opts = {            // 1. to allow shared .serialized between repetitive calls to emitToAudience()
+    hasWildcard: false,   // 2. to avert repetitive test for indexOf(*) in getAudienceGroup()
+    targetAction: action  // 3. to avert repetitive parsing of channel string to determine action in getAudienceGroup()
+  };
 
-  	this.emitToAudience(payload, messageChannel, sharedRef);
-  	this.emitToAudience(payload, '/ALL@' + message.path, sharedRef);
-  	this.emitToAudience(payload, '/ALL@*', sharedRef);
+  	this.emitToAudience(payload, messageChannel, opts);
+    opts.targetAction = 'ALL';
+  	this.emitToAudience(payload, '/ALL@' + message.path, opts);
+  	this.emitToAudience(payload, '/ALL@*', opts);
+
+  opts.hasWildcard = true; // all remaining emit attempts are to wildcard subscribers
 
 	for (var allPath in this.__listeners_wildcard_ALL){
     if (this.happn.utils.wildcardMatch(allPath.replace('/ALL@/','/*@/'), messageChannel)) {
-      this.emitToAudience(payload, allPath, sharedRef);
+      this.emitToAudience(payload, allPath, opts);
     }
 	}
+
+  opts.targetAction = action;
 
 	var wildcardActionGroup = this['__listeners_wildcard_' + action];
 	for (var actionPath in wildcardActionGroup){
 		if (this.happn.utils.wildcardMatch(actionPath, messageChannel)){
-			this.emitToAudience(payload, actionPath, sharedRef);
+			this.emitToAudience(payload, actionPath, opts);
 		}
 	}
 

--- a/lib/services/pubsub/service.js
+++ b/lib/services/pubsub/service.js
@@ -248,6 +248,7 @@ PubSubService.prototype.formatReturnItems = function(items){
 }
 
 PubSubService.prototype.createResponse = function(e, message, response, local) {
+  this.log.info('XXX - createResponse()');
   var _this = this;
 
 	if (!response) response = {data:null};
@@ -345,11 +346,15 @@ PubSubService.prototype.decodeArrayResponse = function(response) {
 
 PubSubService.prototype.handleDataResponseLocal = function(e, message, response, handler, client) {
 
+  this.log.info('XXX - handleDataResponseLocal()');
+
 	if (e) return handler(e);
 
 	if (!response) return handler(null, response);
 
 	var localResponse = this.createResponse(null, message, response, true);
+
+  this.log.info('XXX - createResponse() done');
 
 	var decoded;
 
@@ -737,6 +742,7 @@ PubSubService.prototype.disconnect = function(socket) {
 }
 
 PubSubService.prototype.getAudienceGroup = function(channel) {
+  this.log.info('XXX - getAudienceGroup()');
 	var _this = this;
 
 	if (channel == '/ALL@*')//listeners subscribed to everything
@@ -757,6 +763,7 @@ PubSubService.prototype.getAudienceGroup = function(channel) {
 }
 
 PubSubService.prototype.emitToAudience = function(publication, channel, sharedRef) {
+  this.log.info('XXX - emitToAudience()');
 	var _this = this;
 
 	var audienceGroup = _this.getAudienceGroup(channel);
@@ -794,6 +801,8 @@ PubSubService.prototype.emitToAudience = function(publication, channel, sharedRe
 			decoupledPublication._meta.channel = channel.toString();
 			decoupledPublication._meta.sessionId = _this.__sessions[sessionIndex].session.id;
 
+      this.log.info('XXX - emitToAudience() writing');
+
 			_this.__sessions[sessionIndex].write(decoupledPublication);
 
 		}
@@ -801,6 +810,7 @@ PubSubService.prototype.emitToAudience = function(publication, channel, sharedRe
 }
 
 PubSubService.prototype.publish = function(message, payload) {
+  this.log.info('XXX - publish()');
 
 	payload._meta.published = true;
 

--- a/lib/services/pubsub/service.js
+++ b/lib/services/pubsub/service.js
@@ -248,7 +248,7 @@ PubSubService.prototype.formatReturnItems = function(items){
 }
 
 PubSubService.prototype.createResponse = function(e, message, response, local) {
-  this.log.info('XXX - createResponse()');
+  // this.log.info('XXX - createResponse()');
   var _this = this;
 
 	if (!response) response = {data:null};
@@ -346,7 +346,7 @@ PubSubService.prototype.decodeArrayResponse = function(response) {
 
 PubSubService.prototype.handleDataResponseLocal = function(e, message, response, handler, client) {
 
-  this.log.info('XXX - handleDataResponseLocal()');
+  // this.log.info('XXX - handleDataResponseLocal()');
 
 	if (e) return handler(e);
 
@@ -354,7 +354,7 @@ PubSubService.prototype.handleDataResponseLocal = function(e, message, response,
 
 	var localResponse = this.createResponse(null, message, response, true);
 
-  this.log.info('XXX - createResponse() done');
+  // this.log.info('XXX - createResponse() done');
 
 	var decoded;
 
@@ -742,7 +742,7 @@ PubSubService.prototype.disconnect = function(socket) {
 }
 
 PubSubService.prototype.getAudienceGroup = function(channel, opts) {
-  this.log.info('XXX - getAudienceGroup() %s', channel);
+  // this.log.info('XXX - getAudienceGroup() %s', channel);
 
   var _this = this;
 
@@ -767,7 +767,7 @@ PubSubService.prototype.getAudienceGroup = function(channel, opts) {
 }
 
 PubSubService.prototype.emitToAudience = function(publication, channel, opts) {
-  this.log.info('XXX - emitToAudience() %s', channel);
+  // this.log.info('XXX - emitToAudience() %s', channel);
 	var _this = this;
 
 	var audienceGroup = _this.getAudienceGroup(channel, opts);
@@ -806,7 +806,7 @@ PubSubService.prototype.emitToAudience = function(publication, channel, opts) {
 			decoupledPublication._meta.channel = channel.toString();
 			decoupledPublication._meta.sessionId = _this.__sessions[sessionIndex].session.id;
 
-      this.log.info('XXX - emitToAudience() writing');
+      // this.log.info('XXX - emitToAudience() writing');
 
 			_this.__sessions[sessionIndex].write(decoupledPublication);
 
@@ -815,7 +815,7 @@ PubSubService.prototype.emitToAudience = function(publication, channel, opts) {
 }
 
 PubSubService.prototype.publish = function(message, payload) {
-  this.log.info('XXX - publish()');
+  // this.log.info('XXX - publish()');
 
 	payload._meta.published = true;
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "benchmarket": "0.0.11",
     "chai": "^3.5.0",
     "coveralls": "^2.11.6",
+    "debug": "^2.2.0",
     "expect.js": "*",
     "gulp": "^3.9.1",
     "happn-random-activity-generator": "^0.2.0",

--- a/test/test-benchmark/9_multiple_subscribers_benchmarks.js
+++ b/test/test-benchmark/9_multiple_subscribers_benchmarks.js
@@ -7,6 +7,7 @@ var happn = require('../../lib/index');
 var service = happn.service;
 var client = happn.client;
 var Promise = require('bluebird');
+var debug = require('debug')('TEST');
 
 describe(name, function() {
 
@@ -132,8 +133,12 @@ describe(name, function() {
           events++;
           // console.log('handling ' + meta.path + ', seq:' + events);
           if (events === endAt) { // only end test after last handler runs
-            _this.endTest();
-            delete _this.endTest;
+            process.nextTick(function() {
+              debug('XXX -- END TEST -- received emit()');
+              _this.happnServer.log.info('XXX -- END TEST -- received emit()');
+              _this.endTest();
+              delete _this.endTest;
+            });
           }
         });
       }).then(function() {
@@ -146,14 +151,17 @@ describe(name, function() {
     });
 
     it('emits ' + 1 + ' event', function(done) {
+      debug('XXX -- START TEST -- calling set()');
+      this.happnServer.log.info('XXX -- START TEST -- calling set()');
       this.timeout(subscriberCount * emitCount / 10);
       this.endTest = done;
       this.publisher.set('/some/path/0', {da: 'ta'});
+      this.publisher.set('/some/path/0', {da: 'ta'}, {noStore: true});
     });
 
   }
 
-  require('benchmarket').start();
+  // require('benchmarket').start();
   // after(require('benchmarket').store());
 
   xcontext('with no cache and 20 wildcard subscribers', function() {
@@ -176,15 +184,6 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 2000 separate subscribers on 2000 separate events', function() {
-
-    subscriberCount = 2000;
-    eventCount = 2000;
-
-    testMultipleSeparateSubscribers(subscriberCount, eventCount);
-
-  });
-
   context('with no cache and 20 separate subscribers on 20 separate events', function() {
 
     subscriberCount = 20;
@@ -194,7 +193,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 200 separate subscribers on 200 separate events', function() {
+  xcontext('with no cache and 200 separate subscribers on 200 separate events', function() {
 
     subscriberCount = 200;
     eventCount = 200;
@@ -203,7 +202,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 1 separate subscribers on 200 separate events', function() {
+  xcontext('with no cache and 1 separate subscribers on 200 separate events', function() {
 
     subscriberCount = 1;
     eventCount = 200;
@@ -212,6 +211,15 @@ describe(name, function() {
 
   });
 
-  require('benchmarket').stop();
+  context('with no cache and 2000 separate subscribers on 2000 separate events', function() {
+
+    subscriberCount = 2000;
+    eventCount = 2000;
+
+    testMultipleSeparateSubscribers(subscriberCount, eventCount);
+
+  });
+
+  // require('benchmarket').stop();
 
 });

--- a/test/test-benchmark/9_multiple_subscribers_benchmarks.js
+++ b/test/test-benchmark/9_multiple_subscribers_benchmarks.js
@@ -168,7 +168,7 @@ describe(name, function() {
   // require('benchmarket').start();
   // after(require('benchmarket').store());
 
-  context('with no cache and 20 wildcard subscribers', function() {
+  context('with no cache and 20 same wildcard subscribers', function() {
 
     subscriberCount = 20;
     eventCount = 10;
@@ -178,7 +178,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 200 wildcard subscribers', function() {
+  context('with no cache and 200 same wildcard subscribers', function() {
 
     subscriberCount = 200;
     eventCount = 10;

--- a/test/test-benchmark/9_multiple_subscribers_benchmarks.js
+++ b/test/test-benchmark/9_multiple_subscribers_benchmarks.js
@@ -11,14 +11,14 @@ var debug = require('debug')('TEST');
 
 describe(name, function() {
 
-  function createServerAndSubscribers(subscriberCount) {
+  function createServerAndSubscribers(subscriberCount, loglevel) {
 
     before('start happn server', function(done) {
       this.timeout(0);
       var _this = this;
       service.create({
         utils: {
-          logLevel: 'warn'
+          logLevel: loglevel || 'warn'
         }
       }).then(function(server) {
         _this.happnServer = server;
@@ -168,7 +168,7 @@ describe(name, function() {
   // require('benchmarket').start();
   // after(require('benchmarket').store());
 
-  context('with no cache and 20 same wildcard subscribers', function() {
+  xcontext('with no cache and 20 same wildcard subscribers', function() {
 
     subscriberCount = 20;
     eventCount = 10;
@@ -178,7 +178,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 200 same wildcard subscribers', function() {
+  xcontext('with no cache and 200 same wildcard subscribers', function() {
 
     subscriberCount = 200;
     eventCount = 10;
@@ -188,7 +188,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 20 different wildcard subscribers repeating', function() {
+  xcontext('with no cache and 20 different wildcard subscribers repeating', function() {
 
     subscriberCount = 20;
     eventCount = 10;
@@ -198,7 +198,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 200 different wildcard subscribers repeating', function() {
+  xcontext('with no cache and 200 different wildcard subscribers repeating', function() {
 
     subscriberCount = 200;
     eventCount = 10;
@@ -208,7 +208,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 20 different wildcard subscribers not repeating', function() {
+  xcontext('with no cache and 20 different wildcard subscribers not repeating', function() {
 
     subscriberCount = 20;
     eventCount = 10;
@@ -218,7 +218,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 200 different wildcard subscribers not repeating', function() {
+  xcontext('with no cache and 200 different wildcard subscribers not repeating', function() {
 
     subscriberCount = 200;
     eventCount = 10;
@@ -228,7 +228,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 1 separate subscribers on 20 separate events', function() {
+  xcontext('with no cache and 1 separate subscribers on 20 separate events', function() {
 
     subscriberCount = 1;
     eventCount = 20;
@@ -237,7 +237,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 1 separate subscribers on 200 separate events', function() {
+  xcontext('with no cache and 1 separate subscribers on 200 separate events', function() {
 
     subscriberCount = 1;
     eventCount = 200;
@@ -246,7 +246,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 1 separate subscribers on 2000 separate events', function() {
+  xcontext('with no cache and 1 separate subscribers on 2000 separate events', function() {
 
     subscriberCount = 1;
     eventCount = 2000;
@@ -255,7 +255,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 20 separate subscribers on 20 separate events', function() {
+  xcontext('with no cache and 20 separate subscribers on 20 separate events', function() {
 
     subscriberCount = 20;
     eventCount = 20;
@@ -264,7 +264,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 200 separate subscribers on 200 separate events', function() {
+  xcontext('with no cache and 200 separate subscribers on 200 separate events', function() {
 
     subscriberCount = 200;
     eventCount = 200;
@@ -273,7 +273,7 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 2000 separate subscribers on 2000 separate events', function() {
+  xcontext('with no cache and 2000 separate subscribers on 2000 separate events', function() {
 
     subscriberCount = 2000;
     eventCount = 2000;
@@ -283,5 +283,46 @@ describe(name, function() {
   });
 
   // require('benchmarket').stop();
+
+  context('discover', function() {
+
+    createServerAndSubscribers(1, 'info');
+
+    before('subscribe to events', function(done) {
+      var _this = this;
+      var client = this.subscribers[0];
+
+      // client.onAll(
+      //   function handler(data, meta) {
+      //     process.nextTick(function() {
+      //       debug('XXX -- END TEST -- received emit()');
+      //       _this.endTest();
+      //     });
+      //   },
+      //   function ok() {
+      //     done();
+      //   }
+      // );
+
+      client.on('*', function handler(data, meta) {
+      // client.on('/some/*', {event_type: 'set'}, function handler(data, meta) {
+        process.nextTick(function() {
+          debug('XXX -- END TEST -- received emit()');
+          _this.endTest();
+        });
+      }).then(function(){
+        done();
+      }).catch(done);
+    });
+
+    it('emits 1 event', function(done) {
+
+      debug('XXX -- START TEST -- calling set()');
+      this.endTest = done;
+      this.publisher.set('/some/path', {da: 'ta'});
+
+    });
+
+  });
 
 });

--- a/test/test-benchmark/9_multiple_subscribers_benchmarks.js
+++ b/test/test-benchmark/9_multiple_subscribers_benchmarks.js
@@ -10,7 +10,7 @@ var Promise = require('bluebird');
 
 describe(name, function() {
 
-  function testMultipleSubscribers(subscriberCount, eventCount, emitCount) {
+  function testMultipleWildcardSubscribers(subscriberCount, eventCount, emitCount) {
 
     // subscriberCount - how many subscribers to to include in test
     // eventCount - how man different events to send (event0, event1, event2)
@@ -78,26 +78,137 @@ describe(name, function() {
 
   }
 
+  function testMultipleSeparateSubscribers(subscriberCount, eventCount) {
+
+    // many separate subscriptions on different paths
+    // emit to only one of them
+
+    // subscriberCount - how many subscribers to to include in test
+    // eventCount - how many different events to subscribe to
+
+    before('start happn server', function(done) {
+      var _this = this;
+      service.create({
+        utils: {
+          logLevel: 'warn'
+        }
+      }).then(function(server) {
+        _this.happnServer = server;
+        done();
+      }).catch(done);
+    });
+
+    after('stop happn server', function(done) {
+      if (this.happnServer) {
+        return this.happnServer.stop(done);
+      }
+      done();
+    });
+
+    before('start subscribers', function(done) {
+      var _this = this;
+      Promise.resolve(new Array(   subscriberCount   )).map(
+        function() {
+          return client.create({
+            plugin: happn.client_plugins.intra_process,
+            context: _this.happnServer
+          })
+        }
+      ).then(function(subscribersArray) {
+        _this.subscribers = subscribersArray;
+        _this.publisher = subscribersArray[0]; // first subscriber also publisher
+        done();
+      }).catch(done);
+    });
+
+    before('subscribe to events', function(done) {
+      var events = 0;
+      var endAt = 1;
+      var _this = this;
+      Promise.resolve(new Array( eventCount )).map(function(__, i) {
+        var path = '/some/path/' + i;
+        var client = _this.subscribers[i % subscriberCount];
+        return client.on(path, function handler(data, meta) {
+          events++;
+          // console.log('handling ' + meta.path + ', seq:' + events);
+          if (events === endAt) { // only end test after last handler runs
+            _this.endTest();
+            delete _this.endTest;
+          }
+        });
+      }).then(function() {
+        done();
+      }).catch(done);
+    });
+
+    before('cool off', function(done) {
+      setTimeout(done, 1200);
+    });
+
+    it('emits ' + 1 + ' event', function(done) {
+      this.timeout(subscriberCount * emitCount / 10);
+      this.endTest = done;
+      this.publisher.set('/some/path/0', {da: 'ta'});
+    });
+
+  }
+
   require('benchmarket').start();
   // after(require('benchmarket').store());
 
-  context('with no cache and 20 subscribers', function() {
+  xcontext('with no cache and 20 wildcard subscribers', function() {
 
     subscriberCount = 20;
     eventCount = 10;
     emitCount = 1000;
 
-    testMultipleSubscribers(subscriberCount, eventCount, emitCount)
+    testMultipleWildcardSubscribers(subscriberCount, eventCount, emitCount);
 
   });
 
-  xcontext('with no cache and 200 subscribers', function() {
+  xcontext('with no cache and 200 wildcard subscribers', function() {
 
     subscriberCount = 200;
     eventCount = 10;
     emitCount = 1000;
 
-    testMultipleSubscribers(subscriberCount, eventCount, emitCount)
+    testMultipleWildcardSubscribers(subscriberCount, eventCount, emitCount);
+
+  });
+
+  context('with no cache and 2000 separate subscribers on 2000 separate events', function() {
+
+    subscriberCount = 2000;
+    eventCount = 2000;
+
+    testMultipleSeparateSubscribers(subscriberCount, eventCount);
+
+  });
+
+  context('with no cache and 20 separate subscribers on 20 separate events', function() {
+
+    subscriberCount = 20;
+    eventCount = 20;
+
+    testMultipleSeparateSubscribers(subscriberCount, eventCount);
+
+  });
+
+  context('with no cache and 200 separate subscribers on 200 separate events', function() {
+
+    subscriberCount = 200;
+    eventCount = 200;
+
+    testMultipleSeparateSubscribers(subscriberCount, eventCount);
+
+  });
+
+  context('with no cache and 1 separate subscribers on 200 separate events', function() {
+
+    subscriberCount = 1;
+    eventCount = 200;
+
+    testMultipleSeparateSubscribers(subscriberCount, eventCount);
 
   });
 

--- a/test/test-benchmark/9_multiple_subscribers_benchmarks.js
+++ b/test/test-benchmark/9_multiple_subscribers_benchmarks.js
@@ -79,7 +79,7 @@ describe(name, function() {
 
   }
 
-  function testMultipleSeparateSubscribers(subscriberCount, eventCount) {
+  function testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount) {
 
     // many separate subscriptions on different paths
     // emit to only one of them
@@ -184,21 +184,21 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 20 separate subscribers on 20 separate events', function() {
+  xcontext('with no cache and 20 separate subscribers on 20 separate events', function() {
 
     subscriberCount = 20;
     eventCount = 20;
 
-    testMultipleSeparateSubscribers(subscriberCount, eventCount);
+    testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount);
 
   });
 
-  xcontext('with no cache and 200 separate subscribers on 200 separate events', function() {
+  xcontext('with no cache and 1 separate subscribers on 20 separate events', function() {
 
-    subscriberCount = 200;
-    eventCount = 200;
+    subscriberCount = 1;
+    eventCount = 20;
 
-    testMultipleSeparateSubscribers(subscriberCount, eventCount);
+    testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount);
 
   });
 
@@ -207,7 +207,34 @@ describe(name, function() {
     subscriberCount = 1;
     eventCount = 200;
 
-    testMultipleSeparateSubscribers(subscriberCount, eventCount);
+    testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount);
+
+  });
+
+  xcontext('with no cache and 1 separate subscribers on 2000 separate events', function() {
+
+    subscriberCount = 1;
+    eventCount = 2000;
+
+    testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount);
+
+  });
+
+  context('with no cache and 20 separate subscribers on 20 separate events', function() {
+
+    subscriberCount = 20;
+    eventCount = 20;
+
+    testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount);
+
+  });
+
+  context('with no cache and 200 separate subscribers on 200 separate events', function() {
+
+    subscriberCount = 200;
+    eventCount = 200;
+
+    testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount);
 
   });
 
@@ -216,7 +243,7 @@ describe(name, function() {
     subscriberCount = 2000;
     eventCount = 2000;
 
-    testMultipleSeparateSubscribers(subscriberCount, eventCount);
+    testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount);
 
   });
 

--- a/test/test-benchmark/9_multiple_subscribers_benchmarks.js
+++ b/test/test-benchmark/9_multiple_subscribers_benchmarks.js
@@ -59,7 +59,7 @@ describe(name, function() {
     // eventCount - how man different events to send (event0, event1, event2)
     // emitCount - total events to send as the test
 
-    createServerAndSubscribers(subscriberCount);
+    createServerAndSubscribers(subscriberCount, 'warn');
 
     before('subscribe to events', function(done) {
       this.timeout(0);
@@ -304,8 +304,9 @@ describe(name, function() {
       //   }
       // );
 
-      client.on('*', function handler(data, meta) {
-      // client.on('/some/*', {event_type: 'set'}, function handler(data, meta) {
+      // client.on('*', function handler(data, meta) {
+      // client.on('/some/path', function handler(data, meta) {
+      client.on('/some/*', {event_type: 'set'}, function handler(data, meta) {
         process.nextTick(function() {
           debug('XXX -- END TEST -- received emit()');
           _this.endTest();

--- a/test/test-benchmark/9_multiple_subscribers_benchmarks.js
+++ b/test/test-benchmark/9_multiple_subscribers_benchmarks.js
@@ -306,7 +306,8 @@ describe(name, function() {
 
       // client.on('*', function handler(data, meta) {
       // client.on('/some/path', function handler(data, meta) {
-      client.on('/some/*', {event_type: 'set'}, function handler(data, meta) {
+      client.on('/some/*', function handler(data, meta) {
+      // client.on('/some/*', {event_type: 'set'}, function handler(data, meta) {
         process.nextTick(function() {
           debug('XXX -- END TEST -- received emit()');
           _this.endTest();

--- a/test/test-benchmark/9_multiple_subscribers_benchmarks.js
+++ b/test/test-benchmark/9_multiple_subscribers_benchmarks.js
@@ -11,81 +11,7 @@ var debug = require('debug')('TEST');
 
 describe(name, function() {
 
-  function testMultipleWildcardSubscribers(subscriberCount, eventCount, emitCount) {
-
-    // subscriberCount - how many subscribers to to include in test
-    // eventCount - how man different events to send (event0, event1, event2)
-    // emitCount - total events to send as the test
-
-    before('start happn server', function(done) {
-      var _this = this;
-      service.create().then(function(server) {
-        _this.happnServer = server;
-        done();
-      }).catch(done);
-    });
-
-    after('stop happn server', function(done) {
-      if (this.happnServer) {
-        return this.happnServer.stop(done);
-      }
-      done();
-    });
-
-    before('start subscribers', function(done) {
-      var _this = this;
-      Promise.resolve(new Array(   subscriberCount   )).map(
-        function() {
-          return client.create({
-            plugin: happn.client_plugins.intra_process,
-            context: _this.happnServer
-          })
-        }
-      ).then(function(subscribersArray) {
-        _this.subscribers = subscribersArray;
-        _this.publisher = subscribersArray[0]; // first subscriber also publisher
-        done();
-      }).catch(done);
-    });
-
-    before('subscribe to events', function(done) {
-      var events = 0;
-      var endAt = subscriberCount * emitCount;
-      var _this = this;
-      Promise.resolve(this.subscribers).map(function(client) {
-        return client.on('/some/path/*', function handler(data, meta) {
-          events++;
-          // console.log('handling ' + meta.path + ', seq:' + events);
-          if (events === endAt) { // only end test after last handler runs
-            _this.endTest();
-            delete _this.endTest;
-          }
-        });
-      }).then(function() {
-        done();
-      }).catch(done);
-    });
-
-    it('emits ' + emitCount + ' events', function(done) {
-      this.timeout(subscriberCount * emitCount / 10);
-      this.endTest = done;
-      for(var i = 0; i < emitCount; i++) {
-        // if any events go missing (not emitted to subscribers this
-        // test will time out because it only emits just enough events
-        // to satisfy the required total (endAt) where/when endTest() is run
-        this.publisher.set('/some/path/event' + i % eventCount, {da: 'ta'});
-      }
-    });
-
-  }
-
-  function testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount) {
-
-    // many separate subscriptions on different paths
-    // emit to only one of them
-
-    // subscriberCount - how many subscribers to to include in test
-    // eventCount - how many different events to subscribe to
+  function createServerAndSubscribers(subscriberCount) {
 
     before('start happn server', function(done) {
       var _this = this;
@@ -121,6 +47,71 @@ describe(name, function() {
         done();
       }).catch(done);
     });
+  }
+
+  function testMultipleSameWildcardSubscribers(subscriberCount, eventCount, emitCount) {
+
+    // subscriberCount - how many subscribers to to include in test
+    //                   all subscribing to the same wildcard path
+    // eventCount - how man different events to send (event0, event1, event2)
+    // emitCount - total events to send as the test
+
+    createServerAndSubscribers(subscriberCount);
+
+    before('subscribe to events', function(done) {
+      var events = 0;
+      var endAt = subscriberCount * emitCount;
+      var _this = this;
+      Promise.resolve(this.subscribers).map(function(client) {
+        return client.on('/some/path/*', function handler(data, meta) {
+          events++;
+          // console.log('handling ' + meta.path + ', seq:' + events);
+          if (events === endAt) { // only end test after last handler runs
+            _this.endTest();
+            delete _this.endTest;
+          }
+        });
+      }).then(function() {
+        done();
+      }).catch(done);
+    });
+
+    it('emits ' + emitCount + ' events', function(done) {
+      this.timeout(subscriberCount * emitCount / 10);
+      this.endTest = done;
+      for(var i = 0; i < emitCount; i++) {
+        // if any events go missing (not emitted to subscribers this
+        // test will time out because it only emits just enough events
+        // to satisfy the required total (endAt) where/when endTest() is run
+        this.publisher.set('/some/path/event' + i % eventCount, {da: 'ta'});
+      }
+    });
+
+  }
+
+
+  function testMultipleDifferentWildcardSubscribers(subscriberCount, eventCount, emitCount) {
+
+    // subscriberCount - how many subscribers to to include in test
+    //                   all subscribing to different wildcard paths
+    // eventCount - how man different events to send (event0, event1, event2)
+    // emitCount - total events to send as the test
+
+    createServerAndSubscribers(subscriberCount);
+
+  }
+
+
+
+  function testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount) {
+
+    // many separate subscriptions on different paths
+    // emit to only one of them
+
+    // subscriberCount - how many subscribers to to include in test
+    // eventCount - how many different events to subscribe to
+
+    createServerAndSubscribers(subscriberCount);
 
     before('subscribe to events', function(done) {
       var events = 0;
@@ -146,17 +137,13 @@ describe(name, function() {
       }).catch(done);
     });
 
-    before('cool off', function(done) {
-      setTimeout(done, 1200);
-    });
-
     it('emits ' + 1 + ' event', function(done) {
       debug('XXX -- START TEST -- calling set()');
       this.happnServer.log.info('XXX -- START TEST -- calling set()');
       this.timeout(subscriberCount * emitCount / 10);
       this.endTest = done;
       this.publisher.set('/some/path/0', {da: 'ta'});
-      this.publisher.set('/some/path/0', {da: 'ta'}, {noStore: true});
+      // this.publisher.set('/some/path/0', {da: 'ta'}, {noStore: true});
     });
 
   }
@@ -164,36 +151,47 @@ describe(name, function() {
   // require('benchmarket').start();
   // after(require('benchmarket').store());
 
-  xcontext('with no cache and 20 wildcard subscribers', function() {
+  context('with no cache and 20 wildcard subscribers', function() {
 
     subscriberCount = 20;
     eventCount = 10;
     emitCount = 1000;
 
-    testMultipleWildcardSubscribers(subscriberCount, eventCount, emitCount);
+    testMultipleSameWildcardSubscribers(subscriberCount, eventCount, emitCount);
 
   });
 
-  xcontext('with no cache and 200 wildcard subscribers', function() {
+  context('with no cache and 200 wildcard subscribers', function() {
 
     subscriberCount = 200;
     eventCount = 10;
     emitCount = 1000;
 
-    testMultipleWildcardSubscribers(subscriberCount, eventCount, emitCount);
+    testMultipleSameWildcardSubscribers(subscriberCount, eventCount, emitCount);
 
   });
 
-  xcontext('with no cache and 20 separate subscribers on 20 separate events', function() {
+  context('with no cache and 20 different wildcard subscribers', function() {
 
     subscriberCount = 20;
-    eventCount = 20;
+    eventCount = 10;
+    emitCount = 1000;
 
-    testMultipleSeparateSubscribersOneEmit(subscriberCount, eventCount);
+    testMultipleDifferentWildcardSubscribers(subscriberCount, eventCount, emitCount);
 
   });
 
-  xcontext('with no cache and 1 separate subscribers on 20 separate events', function() {
+  context('with no cache and 200 different wildcard subscribers', function() {
+
+    subscriberCount = 200;
+    eventCount = 10;
+    emitCount = 1000;
+
+    testMultipleDifferentWildcardSubscribers(subscriberCount, eventCount, emitCount);
+
+  });
+
+  context('with no cache and 1 separate subscribers on 20 separate events', function() {
 
     subscriberCount = 1;
     eventCount = 20;
@@ -202,7 +200,7 @@ describe(name, function() {
 
   });
 
-  xcontext('with no cache and 1 separate subscribers on 200 separate events', function() {
+  context('with no cache and 1 separate subscribers on 200 separate events', function() {
 
     subscriberCount = 1;
     eventCount = 200;
@@ -211,7 +209,7 @@ describe(name, function() {
 
   });
 
-  xcontext('with no cache and 1 separate subscribers on 2000 separate events', function() {
+  context('with no cache and 1 separate subscribers on 2000 separate events', function() {
 
     subscriberCount = 1;
     eventCount = 2000;

--- a/test/test-benchmark/9_multiple_subscribers_benchmarks.js
+++ b/test/test-benchmark/9_multiple_subscribers_benchmarks.js
@@ -14,6 +14,7 @@ describe(name, function() {
   function createServerAndSubscribers(subscriberCount) {
 
     before('start happn server', function(done) {
+      this.timeout(0);
       var _this = this;
       service.create({
         utils: {
@@ -26,6 +27,7 @@ describe(name, function() {
     });
 
     after('stop happn server', function(done) {
+      this.timeout(0);
       if (this.happnServer) {
         return this.happnServer.stop(done);
       }
@@ -33,6 +35,7 @@ describe(name, function() {
     });
 
     before('start subscribers', function(done) {
+      this.timeout(0);
       var _this = this;
       Promise.resolve(new Array(   subscriberCount   )).map(
         function() {
@@ -59,6 +62,7 @@ describe(name, function() {
     createServerAndSubscribers(subscriberCount);
 
     before('subscribe to events', function(done) {
+      this.timeout(0);
       var events = 0;
       var endAt = subscriberCount * emitCount;
       var _this = this;
@@ -77,11 +81,11 @@ describe(name, function() {
     });
 
     it('emits ' + emitCount + ' events', function(done) {
-      this.timeout(subscriberCount * emitCount / 10);
+      this.timeout(0);
       this.endTest = done;
       for(var i = 0; i < emitCount; i++) {
         // if any events go missing (not emitted to subscribers this
-        // test will time out because it only emits just enough events
+        // test go on forever because it only emits just enough events
         // to satisfy the required total (endAt) where/when endTest() is run
         this.publisher.set('/some/path/event' + i % eventCount, {da: 'ta'});
       }
@@ -90,12 +94,23 @@ describe(name, function() {
   }
 
 
-  function testMultipleDifferentWildcardSubscribers(subscriberCount, eventCount, emitCount) {
+  function testMultipleDifferentWildcardSubscribersRepeating(subscriberCount, eventCount, emitCount) {
 
     // subscriberCount - how many subscribers to to include in test
     //                   all subscribing to different wildcard paths
     // eventCount - how man different events to send (event0, event1, event2)
-    // emitCount - total events to send as the test
+    // emitCount - total events to send as the test where the emitted paths repeat
+
+    createServerAndSubscribers(subscriberCount);
+
+  }
+
+  function testMultipleDifferentWildcardSubscribersNotRepeating(subscriberCount, eventCount, emitCount) {
+
+    // subscriberCount - how many subscribers to to include in test
+    //                   all subscribing to different wildcard paths
+    // eventCount - how man different events to send (event0, event1, event2)
+    // emitCount - total events to send as the test where the emitted paths do not repeat
 
     createServerAndSubscribers(subscriberCount);
 
@@ -114,6 +129,7 @@ describe(name, function() {
     createServerAndSubscribers(subscriberCount);
 
     before('subscribe to events', function(done) {
+      this.timeout(0);
       var events = 0;
       var endAt = 1;
       var _this = this;
@@ -138,6 +154,7 @@ describe(name, function() {
     });
 
     it('emits ' + 1 + ' event', function(done) {
+      this.timeout(0);
       debug('XXX -- START TEST -- calling set()');
       this.happnServer.log.info('XXX -- START TEST -- calling set()');
       this.timeout(subscriberCount * emitCount / 10);
@@ -171,23 +188,43 @@ describe(name, function() {
 
   });
 
-  context('with no cache and 20 different wildcard subscribers', function() {
+  context('with no cache and 20 different wildcard subscribers repeating', function() {
 
     subscriberCount = 20;
     eventCount = 10;
     emitCount = 1000;
 
-    testMultipleDifferentWildcardSubscribers(subscriberCount, eventCount, emitCount);
+    testMultipleDifferentWildcardSubscribersRepeating(subscriberCount, eventCount, emitCount);
 
   });
 
-  context('with no cache and 200 different wildcard subscribers', function() {
+  context('with no cache and 200 different wildcard subscribers repeating', function() {
 
     subscriberCount = 200;
     eventCount = 10;
     emitCount = 1000;
 
-    testMultipleDifferentWildcardSubscribers(subscriberCount, eventCount, emitCount);
+    testMultipleDifferentWildcardSubscribersRepeating(subscriberCount, eventCount, emitCount);
+
+  });
+
+  context('with no cache and 20 different wildcard subscribers not repeating', function() {
+
+    subscriberCount = 20;
+    eventCount = 10;
+    emitCount = 1000;
+
+    testMultipleDifferentWildcardSubscribersNotRepeating(subscriberCount, eventCount, emitCount);
+
+  });
+
+  context('with no cache and 200 different wildcard subscribers not repeating', function() {
+
+    subscriberCount = 200;
+    eventCount = 10;
+    emitCount = 1000;
+
+    testMultipleDifferentWildcardSubscribersNotRepeating(subscriberCount, eventCount, emitCount);
 
   });
 


### PR DESCRIPTION
Made some additional optimisations:

By carrying the known values for `targetAction` and `hasWildcard` **all string manipulations in `getAudienceGroup()` are removed**. (see lib/services/pubsub/service.js)

Hard to get an exact fix on the improvement because the test times vary at a greater amplitude than the improvement.

But what is certain is that the `getAudienceGroup()` is called a minimum of three times with each emit and a further N times depending on how many wildcard subscription audiences further match the emitted path.
