### PR TITLE
Fix overlapping this in server 2.15.3

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -343,4 +343,7 @@
 
 - fixed protocol heading on client file
 
+2.15.3 2016-10-22
+-----------------
 
+- fixed overlapping `this` in `happn.service.create()`

--- a/lib/service.js
+++ b/lib/service.js
@@ -192,7 +192,7 @@ module.exports = {
               log.$$DEBUG('stopped services');
 
               stopCB();
-            }.bind(this)
+            }
           );
         });
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -19,7 +19,7 @@ module.exports = {
 
   create: utils.promisify(function (config, done) {
 
-    var _this = this;
+    var instance = {};
 
     if (typeof config == 'function') {
       done = config;
@@ -79,7 +79,7 @@ module.exports = {
     happn.utils = utils;
     happn.connect = app;
 
-    _this.__initialized = false;
+    instance.__initialized = false;
 
     transport.createServer(config.transport, app, log, function (e, server) {
 
@@ -89,7 +89,7 @@ module.exports = {
 
       Object.defineProperty(happn.server, 'listening', {
         get: function () {
-          return _this.__happn.__listening;
+          return instance.__happn.__listening;
         },
         enumerable: 'true'
       });
@@ -196,8 +196,8 @@ module.exports = {
           );
         });
 
-        _this.__config = config;
-        _this.__initialized = true;
+        instance.__config = config;
+        instance.__initialized = true;
 
         happn.__listening = false;
         happn.__erroredOnStart = false;
@@ -208,7 +208,7 @@ module.exports = {
           enumerable: false,
           configurable: false,
           writable: false,
-          value: _this
+          value: instance
         });
 
         happn.listen = function (host, port, callback) {
@@ -253,7 +253,7 @@ module.exports = {
               }
 
             }.bind(this));
-            _this.__errorOn = true;
+            this.__errorOn = true;
           }
 
           if (!this.__listeningOn) {
@@ -282,15 +282,15 @@ module.exports = {
         if (config.port == undefined || config.port == null)
           config.port = 55000;
 
-        _this.__happn = happn;
+        instance.__happn = happn;
 
-        _this.__happn.__defaultHost = config.host == null ? '0.0.0.0' : config.host;
-        _this.__happn.__defaultPort = config.port;
+        instance.__happn.__defaultHost = config.host == null ? '0.0.0.0' : config.host;
+        instance.__happn.__defaultPort = config.port;
 
         if (!config.deferListen)
-          _this.__happn.listen(done);
+          instance.__happn.listen(done);
         else {
-          done(null, _this.__happn);
+          done(null, instance.__happn);
         }
 
       });

--- a/lib/service.js
+++ b/lib/service.js
@@ -1,13 +1,17 @@
-var async = require('async')
+var Logger = require('happn-logger')
+  , async = require('async')
   , connect = require('connect')
   , cookies = require('connect-cookies')
-  , utils = require('./utils')
   , serveStatic = require('serve-static')
   , shortid = require('shortid')
-  , Logger = require('happn-logger')
-  , transport = require('./transport')
   , Crypto = require('happn-util-crypto')
   , crypto = new Crypto()
+  , bodyParser = require('body-parser')
+
+  , utils = require('./utils')
+  , transport = require('./transport')
+  , services = require('./services')
+  , version = require('../package.json').version
   ;
 
 module.exports = {
@@ -49,7 +53,6 @@ module.exports = {
     var app = connect();
 
     app.use(serveStatic(__dirname + '/public'));
-    var bodyParser = require('body-parser');
     app.use(bodyParser.json());
     app.use(cookies());
 
@@ -113,7 +116,7 @@ module.exports = {
           log.info('released, no info');
       });
 
-      require('./services').initialize(config, happn, log, function (e) {
+      services.initialize(config, happn, log, function (e) {
 
         if (e) {
           log.fatal('Failed to initialize services', e);
@@ -165,7 +168,7 @@ module.exports = {
           }
 
           if (options.kill) {
-            timeout = setTimeout(function () {
+            setTimeout(function () {
               log.error('failed to stop happn, force true');
               kill();
             }, options.wait);
@@ -249,7 +252,7 @@ module.exports = {
               // eg. EADDRINUSE
               if (happn.__done) {
                 happn.__done(e, happn);
-                happn.__done == null;//we only want this to be called once per call to listen
+                happn.__done = null;//we only want this to be called once per call to listen
               }
 
             });
@@ -263,11 +266,11 @@ module.exports = {
               happn.__listening = true;
 
               happn.log.info('listening at ' + happn.__info.address + ':' + happn.__info.port);
-              happn.log.info('happn version ' + require('../package.json').version);
+              happn.log.info('happn version ' + version);
 
               if (happn.__done) {
                 happn.__done(null, happn); // <--- good, created a happn
-                happn.__done == null;//we only want this to be called once per call to listen
+                happn.__done = null;//we only want this to be called once per call to listen
               }
 
             });

--- a/lib/service.js
+++ b/lib/service.js
@@ -140,13 +140,13 @@ module.exports = {
 
         happn.dropConnections = function () {
           //drop all connections
-          for (var key in this.connections) {
+          for (var key in happn.connections) {
             log.$$TRACE('killing connection', key);
             happn.connections[key].destroy();
           }
 
           log.$$TRACE('killed connections');
-        }.bind(happn);
+        };
 
         happn.stop = utils.promisify(function (options, stopCB) {
 
@@ -213,8 +213,8 @@ module.exports = {
 
         happn.listen = function (host, port, callback) {
 
-          if (this.__listening) return callback(new Error('already listening'));
-          if (!this.__factory.__initialized) return done(new Error('main happn service not initialized'));
+          if (happn.__listening) return callback(new Error('already listening'));
+          if (!happn.__factory.__initialized) return done(new Error('main happn service not initialized'));
 
           if (typeof host == 'function') {
             callback = host;
@@ -228,56 +228,56 @@ module.exports = {
           }
 
           // preserve zero as valid port number
-          port = port !== 'undefined' ? port : this.__defaultPort;
+          port = port !== 'undefined' ? port : happn.__defaultPort;
 
           //nulls aren't provided for in the above
-          if (port == null) port = this.__defaultPort;
+          if (port == null) port = happn.__defaultPort;
 
           //default host is local/any
-          host = host || this.__defaultHost;
+          host = host || happn.__defaultHost;
 
-          this.__done = callback;
+          happn.__done = callback;
 
-          if (!this.__errorOn) {
-            this.server.on('error', function (e) {
+          if (!happn.__errorOn) {
+            happn.server.on('error', function (e) {
 
-              this._lastError = e;
-              this.log.warn('http server error', e);
+              happn._lastError = e;
+              happn.log.warn('http server error', e);
 
               // Error before listening achieved
               //
               // eg. EADDRINUSE
-              if (this.__done) {
-                this.__done(e, this);
-                this.__done == null;//we only want this to be called once per call to listen
+              if (happn.__done) {
+                happn.__done(e, happn);
+                happn.__done == null;//we only want this to be called once per call to listen
               }
 
-            }.bind(this));
-            this.__errorOn = true;
+            });
+            happn.__errorOn = true;
           }
 
-          if (!this.__listeningOn) {
-            this.server.on('listening', function () {
+          if (!happn.__listeningOn) {
+            happn.server.on('listening', function () {
 
-              this.__info = this.server.address();
-              this.__listening = true;
+              happn.__info = happn.server.address();
+              happn.__listening = true;
 
-              this.log.info('listening at ' + this.__info.address + ':' + this.__info.port);
-              this.log.info('happn version ' + require('../package.json').version);
+              happn.log.info('listening at ' + happn.__info.address + ':' + happn.__info.port);
+              happn.log.info('happn version ' + require('../package.json').version);
 
-              if (this.__done) {
-                this.__done(null, this); // <--- good, created a happn
-                this.__done == null;//we only want this to be called once per call to listen
+              if (happn.__done) {
+                happn.__done(null, happn); // <--- good, created a happn
+                happn.__done == null;//we only want this to be called once per call to listen
               }
 
-            }.bind(this));
-            this.__listeningOn = true;
+            });
+            happn.__listeningOn = true;
           }
 
-          this.log.$$TRACE('listen()');
-          this.server.listen(port, host);
+          happn.log.$$TRACE('listen()');
+          happn.server.listen(port, host);
 
-        }.bind(happn);
+        };
 
         if (config.port == undefined || config.port == null)
           config.port = 55000;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "happn",
   "description": "pub/sub api as a service using primus and mongo & redis or nedb, can work as cluster, single process or embedded using nedb, use in production at your own risk",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "main": "./lib/index",
   "protocol":"1.1.0",
   "scripts": {


### PR DESCRIPTION
There was a shared `this` in `Happn.service.create()`.

Also tidied up a few other things.