### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/services/cache/service.js
+++ b/lib/services/cache/service.js
@@ -1,5 +1,5 @@
 var shortid = require('shortid');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var EventEmitter = require("events").EventEmitter;
 var util = require('util');
 

--- a/lib/services/crypto/service.js
+++ b/lib/services/crypto/service.js
@@ -1,5 +1,5 @@
 var shortid = require('shortid');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 module.exports = CryptoService;
 

--- a/lib/services/data/service.js
+++ b/lib/services/data/service.js
@@ -1,6 +1,6 @@
 var _s = require('underscore.string')
   , traverse = require('traverse')
-  , uuid = require('node-uuid')
+  , uuid = require('uuid')
   , async = require('async')
 ;
 

--- a/lib/services/security/service.js
+++ b/lib/services/security/service.js
@@ -1,5 +1,5 @@
 var jwt = require('jwt-simple')
-  , uuid = require('node-uuid')
+  , uuid = require('uuid')
   , LRU = require("lru-cache")
   , sift = require('sift')
   ;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "pub/sub api as a service using primus and mongo & redis or nedb, can work as cluster, single process or embedded using nedb, use in production at your own risk",
   "version": "2.16.2",
   "main": "./lib/index",
-  "protocol":"1.1.0",
+  "protocol": "1.1.0",
   "scripts": {
     "test": "mocha --expose-gc silence.js test",
     "test-cover": "istanbul cover _mocha -- silence.js test",
@@ -39,7 +39,6 @@
     "long-timeout": "0.1.1",
     "lru-cache": "4.0.0",
     "ms": "0.7.1",
-    "node-uuid": "1.4.7",
     "password-hash-and-salt": "0.1.3",
     "pem": "1.8.3",
     "primus": "4.0.5",
@@ -50,6 +49,7 @@
     "traverse": "0.6.6",
     "underscore.string": "3.3.4",
     "user-home": "2.0.0",
+    "uuid": "^3.0.0",
     "ws": "1.0.1"
   },
   "devDependencies": {

--- a/test/d3_security_tokens.js
+++ b/test/d3_security_tokens.js
@@ -8,7 +8,7 @@ describe('d3-security-tokens', function () {
   var happn = require('../lib/index');
   var service = happn.service;
   var async = require('async');
-  var uuid = require('node-uuid');
+  var uuid = require('uuid');
   var Logger = require('happn-logger');
   var CheckPoint = require('../lib/services/security/checkpoint');
   /*


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.